### PR TITLE
Allow AI crawlers in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,13 @@
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
 User-agent: *
 Allow: /
+
 Sitemap: https://yourdomain.co.uk/sitemap-index.xml


### PR DESCRIPTION
## Summary
- add explicit Allow sections for GPTBot, ChatGPT-User, and PerplexityBot
- preserve general Allow rule and sitemap entry

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ced8b8baf08323acca861dca9ba132