### PR TITLE
Add canonical metadata to Base layout

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -6,8 +6,10 @@ const {
   title = "Web Dhiveloper — Websites that win you work",
   description = "10-day launches with monthly growth: new pages, SEO tweaks, and website care for SMEs & trades.",
   metaImage = "/images/logo.webp",
-  url = "https://yourdomain.co.uk/",
+  url: canonicalOverride,
 } = Astro.props;
+
+const canonicalUrl = canonicalOverride ?? Astro.url.href;
 ---
 <html lang="en-GB">
   <head>
@@ -19,8 +21,14 @@ const {
     <meta property="og:description" content={description} />
     <meta property="og:image" content={metaImage} />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content={url} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={metaImage} />
+    <meta name="twitter:url" content={canonicalUrl} />
     <link rel="icon" href="/favicon.ico" />
+    <link rel="canonical" href={canonicalUrl} />
   </head>
   <body class="bg-slate-50 text-slate-900">
     <Header />


### PR DESCRIPTION
## Summary
- derive the canonical URL from the current request in the Base layout and expose it via the canonical link and Open Graph tags
- add Twitter card metadata so title, description, image, and URL mirror the existing Open Graph values

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cedcfd866483238d93e60c04a3dfbf