### PR TITLE
Add Netlify redirect rule for bare domain

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,1 @@
+https://www.webdhiveloper.co.uk/* https://webdhiveloper.co.uk/:splat 301!


### PR DESCRIPTION
## Summary
- add a Netlify `_redirects` rule so www traffic is forced to the bare domain

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cedcfe702483239cbd39015257d62f