### PR TITLE
Add llms manifest placeholder and reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,4 @@ A fast static website for your agency: **Astro + Tailwind**, **Markdown case stu
 - Update email and phone in `src/components/Footer.astro`.
 - Replace `site` in `astro.config.mjs` with your domain.
 - Update meta titles/descriptions as you like on each page.
+- Update `public/llms.txt` with the audit-approved LLM policy or allow-list before launch.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,7 @@
+# llms.txt placeholder
+# Replace this file with the official LLM policy or allow-list provided by the security audit team.
+# Until then, this placeholder clarifies that automated LLM agents should contact the team before crawling restricted content.
+
+Contact: security@example.com
+Status: Placeholder pending audit-approved content
+Last-Updated: 2024-01-01

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -11,3 +11,4 @@ User-agent: *
 Allow: /
 
 Sitemap: https://yourdomain.co.uk/sitemap-index.xml
+# LLM manifest: https://yourdomain.co.uk/llms.txt


### PR DESCRIPTION
## Summary
- add a placeholder `llms.txt` in the public directory so the build publishes an llm policy manifest
- reference the manifest from the README checklist and robots.txt for discoverability

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cedcff1c708323b062465add2f8519