### PR TITLE
Add structured data and domain updates for launch readiness

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,6 @@ import tailwind from "@astrojs/tailwind";
 import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
-  site: 'https://yourdomain.co.uk',
+  site: 'https://webdhiveloper.co.uk',
   integrations: [ tailwind({ applyBaseStyles: true }), sitemap() ],
 });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,5 +10,5 @@ Allow: /
 User-agent: *
 Allow: /
 
-Sitemap: https://yourdomain.co.uk/sitemap-index.xml
-# LLM manifest: https://yourdomain.co.uk/llms.txt
+Sitemap: https://webdhiveloper.co.uk/sitemap-index.xml
+# LLM manifest: https://webdhiveloper.co.uk/llms.txt

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,7 +7,7 @@
     </div>
     <div>
       <div class="font-semibold text-slate-900 mb-2">Contact</div>
-      <p>Email: <a href="mailto:hello@webdhiveloper.co.uk">hello@webdhiveloper.co.uk</a><br/>Phone: +44 151 123 4567</p>
+      <p>Email: <a href="mailto:hello@webdhiveloper.co.uk">hello@webdhiveloper.co.uk</a></p>
       <p class="mt-2">Office hours: Mon–Fri, 9am–5pm (UK)</p>
     </div>
     <div>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -7,9 +7,38 @@ const {
   description = "10-day launches with monthly growth: new pages, SEO tweaks, and website care for SMEs & trades.",
   metaImage = "/images/logo.webp",
   url: canonicalOverride,
+  structuredData = [],
 } = Astro.props;
 
+const site = Astro.site ?? new URL('https://webdhiveloper.co.uk');
 const canonicalUrl = canonicalOverride ?? Astro.url.href;
+const absoluteMetaImage = metaImage.startsWith('http') ? metaImage : new URL(metaImage, site).toString();
+
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Web Dhiveloper",
+  url: site.toString().replace(/\/$/, ''),
+  logo: new URL('/images/logo.webp', site).toString(),
+  email: "hello@webdhiveloper.co.uk",
+  contactPoint: [
+    {
+      "@type": "ContactPoint",
+      contactType: "customer service",
+      email: "hello@webdhiveloper.co.uk",
+      availableLanguage: ["English"],
+      areaServed: "GB",
+    },
+  ],
+};
+
+const structuredDataArray = Array.isArray(structuredData)
+  ? structuredData.filter(Boolean)
+  : structuredData
+    ? [structuredData]
+    : [];
+
+const structuredDataEntries = [organizationSchema, ...structuredDataArray];
 ---
 <html lang="en-GB">
   <head>
@@ -19,16 +48,20 @@ const canonicalUrl = canonicalOverride ?? Astro.url.href;
     <meta name="description" content={description} />
     <meta property="og:title" content={title} />
     <meta property="og:description" content={description} />
-    <meta property="og:image" content={metaImage} />
+    <meta property="og:image" content={absoluteMetaImage} />
     <meta property="og:type" content="website" />
     <meta property="og:url" content={canonicalUrl} />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content={metaImage} />
+    <meta name="twitter:image" content={absoluteMetaImage} />
     <meta name="twitter:url" content={canonicalUrl} />
     <link rel="icon" href="/favicon.ico" />
     <link rel="canonical" href={canonicalUrl} />
+    <slot name="head" />
+    {structuredDataEntries.map((data) => (
+      <script type="application/ld+json">{JSON.stringify(data)}</script>
+    ))}
   </head>
   <body class="bg-slate-50 text-slate-900">
     <Header />

--- a/src/layouts/CaseStudy.astro
+++ b/src/layouts/CaseStudy.astro
@@ -2,16 +2,68 @@
 import Base from "./Base.astro";
 const { frontmatter } = Astro.props;
 const { title, date, location, summary, seo = {}, images = [] } = frontmatter ?? {};
+
+const site = Astro.site ?? new URL('https://webdhiveloper.co.uk');
+const canonicalUrl = Astro.url.href;
+
+const galleryImages = images.map((image, index) =>
+  typeof image === 'string'
+    ? { src: image, alt: `${title} case study image ${index + 1}` }
+    : { src: image?.src, alt: image?.alt || `${title} case study image ${index + 1}` },
+);
+
+const imageUrls = galleryImages
+  .filter((image) => Boolean(image?.src))
+  .map((image) => new URL(image.src, site).toString());
+
+const caseStudySchema = [
+  {
+    "@context": "https://schema.org",
+    "@type": "CaseStudy",
+    name: title,
+    headline: summary || title,
+    description: summary,
+    url: canonicalUrl,
+    datePublished: date,
+    image: imageUrls.length ? imageUrls : undefined,
+    author: {
+      "@type": "Organization",
+      name: "Web Dhiveloper",
+      url: site.toString().replace(/\/$/, ''),
+    },
+    publisher: {
+      "@type": "Organization",
+      name: "Web Dhiveloper",
+      logo: {
+        "@type": "ImageObject",
+        url: new URL('/images/logo.webp', site).toString(),
+      },
+    },
+  },
+];
 ---
-<Base title={seo.metaTitle || title} description={seo.metaDescription || summary}>
+<Base
+  title={seo.metaTitle || title}
+  description={seo.metaDescription || summary}
+  structuredData={caseStudySchema}
+>
   <article class="prose prose-slate max-w-none">
     <h1>{title}</h1>
     {date && <p class="text-sm text-slate-500">{new Date(date).toLocaleDateString('en-GB')} • {location}</p>}
     {summary && <p class="lead">{summary}</p>}
     <slot />
-    {images.length > 0 && (
+    {galleryImages.filter((image) => Boolean(image?.src)).length > 0 && (
       <div class="grid md:grid-cols-3 gap-4 not-prose mt-8">
-        {images.map((src) => <img src={src} alt={title} class="rounded-xl w-full h-auto" loading="lazy" />)}
+        {galleryImages
+          .filter((image) => Boolean(image?.src))
+          .map((image) => (
+          <img
+            src={image.src}
+            alt={image.alt}
+            class="rounded-xl w-full h-auto"
+            loading="lazy"
+          />
+        ))}
       </div>
     )}
     <div class="not-prose mt-10">

--- a/src/pages/case-studies/lem-building-surveying.md
+++ b/src/pages/case-studies/lem-building-surveying.md
@@ -8,8 +8,10 @@ seo:
   metaTitle: "LEM Building Surveying Website — Independent RICS Surveyor (Case Study)"
   metaDescription: "10-day rebuild + ongoing content and SEO for LEM Building Surveying, serving Deeside, Chester & the North West."
 images:
-  - "/images/sample-1.jpg"
-  - "/images/sample-2.jpg"
+  - src: "/images/sample-1.jpg"
+    alt: "Mockup of the LEM Building Surveying website homepage highlighting core services"
+  - src: "/images/sample-2.jpg"
+    alt: "Collage of property survey project photography for LEM Building Surveying"
 ---
 
 ## About the client

--- a/src/pages/case-studies/northwest-roofing-solutions.md
+++ b/src/pages/case-studies/northwest-roofing-solutions.md
@@ -8,8 +8,10 @@ seo:
   metaTitle: "NorthWest Roofing Solutions Case Study — Roofing Website & Lead Gen"
   metaDescription: "See how Web Dhiveloper rebuilt NorthWest Roofing Solutions in 10 days and delivered a 112% uplift in web enquiries."
 images:
-  - "/images/sample-1.jpg"
-  - "/images/sample-2.jpg"
+  - src: "/images/sample-1.jpg"
+    alt: "Homepage mockup for NorthWest Roofing Solutions showcasing roofing services and testimonials"
+  - src: "/images/sample-2.jpg"
+    alt: "Before and after roofing project photography for NorthWest Roofing Solutions"
 ---
 
 ## About the client

--- a/src/pages/case-studies/stride-physio-group.md
+++ b/src/pages/case-studies/stride-physio-group.md
@@ -8,7 +8,8 @@ seo:
   metaTitle: "Stride Physio Group Case Study — Clinic Website & Booking Growth"
   metaDescription: "Discover how Web Dhiveloper rebuilt Stride Physio Group’s website, improved conversion copy and increased bookings by 68%."
 images:
-  - "/images/sample-1.jpg"
+  - src: "/images/sample-1.jpg"
+    alt: "Screenshot of the Stride Physio Group website highlighting online booking pathways"
 ---
 
 ## About the client

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,11 @@
 ---
 import Base from "../layouts/Base.astro";
 
+const site = Astro.site ?? new URL('https://webdhiveloper.co.uk');
+const pageTitle = "Web Dhiveloper — Fast websites for trades, clinics & professional services";
+const pageDescription =
+  "Launch fast Astro websites with ongoing SEO, content and care plans tailored for UK trades, clinics and professional services.";
+
 const highlights = [
   {
     title: "Launch in 10 working days",
@@ -111,8 +116,38 @@ const faqs = [
 const caseStudies = (await Astro.glob('./case-studies/*.md'))
   .sort((a, b) => new Date(b.frontmatter.date).valueOf() - new Date(a.frontmatter.date).valueOf())
   .slice(0, 3);
+
+const faqSchema = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  mainEntity: faqs.map((faq) => ({
+    "@type": "Question",
+    name: faq.question,
+    acceptedAnswer: {
+      "@type": "Answer",
+      text: faq.answer,
+    },
+  })),
+};
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  name: pageTitle,
+  url: Astro.url.href,
+  description: pageDescription,
+  inLanguage: "en-GB",
+  isPartOf: {
+    "@type": "WebSite",
+    name: "Web Dhiveloper",
+    url: site.toString().replace(/\/$/, ''),
+  },
+  primaryImageOfPage: new URL('/images/logo.webp', site).toString(),
+};
+
+const structuredData = [webPageSchema, faqSchema];
 ---
-<Base>
+<Base title={pageTitle} description={pageDescription} structuredData={structuredData}>
   <section class="grid lg:grid-cols-2 gap-12 items-center">
     <div class="space-y-6">
       <div class="inline-flex items-center gap-2 rounded-full bg-sky-100 px-4 py-2 text-sm font-medium text-sky-700">


### PR DESCRIPTION
## Summary
- configure the production domain for sitemap generation and crawl directives
- extend the base layout to emit organization JSON-LD, accept per-page schema data, and clean up footer contact details
- add homepage FAQ/webpage schema plus richer case study alt text and CaseStudy schema markup

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d41e0a35e48323920281ac6be76895